### PR TITLE
Add plot for MarginBasedLoss and DistanceBasedLoss

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 
 Reexport
 Plots
+LearnBase

--- a/src/MLPlots.jl
+++ b/src/MLPlots.jl
@@ -2,10 +2,12 @@ module MLPlots
 
 using Reexport
 @reexport using Plots
+using LearnBase
 
 export
     corrplot
 
 include("recipes.jl")
+include("loss.jl")
 
 end # module

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -1,0 +1,42 @@
+typealias CLoss Union{LossFunctions.MarginBasedLoss, LossFunctions.ZeroOneLoss}
+typealias DLoss LossFunctions.DistanceBasedLoss
+
+_loss_xlabel(loss::CLoss) = "y ⋅ h(x)"
+_loss_xlabel(loss::DLoss) = "h(x) - y"
+
+function Plots.plot(loss::SupervisedLoss; kw...)
+    Plots.plot(loss, -2, 2; kw...)
+end
+
+function Plots.plot(loss::SupervisedLoss, args...;
+                    xlabel = _loss_xlabel(loss),
+                    ylabel = "L(y, h(x))",
+                    label = string(loss),
+                    kw...)
+    plot(value_fun(loss), args...;
+         xlabel = xlabel,
+         ylabel = ylabel,
+         label = label,
+         kw...)
+end
+
+function Plots.plot{T<:SupervisedLoss}(vec::Vector{T}; kw...)
+    Plots.plot(vec, -2, 2; kw...)
+end
+
+function Plots.plot{T<:SupervisedLoss}(vec::Vector{T}, args...; kw...)
+    @assert length(vec) > 0
+    plt = plot(vec[1], args...; kw...)
+    for loss in vec[2:end]
+        plot!(plt, loss, args...)
+    end
+    plt
+end
+
+function Plots.plot!(plt::Plots.Plot, loss::SupervisedLoss, args...;
+                     label = string(loss),
+                     kw...)
+    plot!(plt, value_fun(loss), args...;
+          label = label,
+          kw...)
+end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -2,7 +2,7 @@
 
 # # TODO: there should be a distinction between an object that will manage a full plot, vs a component of a plot.
 # # the PlotRecipe as currently implemented is more of a "custom component"
-# # a recipe should fully describe the plotting command(s) and call them, likewise for updating. 
+# # a recipe should fully describe the plotting command(s) and call them, likewise for updating.
 # #   actually... maybe those should explicitly derive from PlottingObject???
 
 # abstract PlotRecipe
@@ -64,13 +64,13 @@ end
 
 
 "Correlation scatter matrix"
-function corrplot{T<:Real,S<:Real}(mat::AMat{T}, corrmat::AMat{S} = cor(mat);
+function corrplot{T<:Real,S<:Real}(mat::Plots.AMat{T}, corrmat::Plots.AMat{S} = cor(mat);
                                    colors = :redsblues,
                                    labels = nothing, kw...)
     m = size(mat,2)
     centers = Float64[mean(extrema(mat[:,i])) for i in 1:m]
 
-    # might be a mistake? 
+    # might be a mistake?
     @assert m <= 20
     @assert size(corrmat) == (m,m)
 
@@ -109,4 +109,3 @@ function corrplot{T<:Real,S<:Real}(mat::AMat{T}, corrmat::AMat{S} = cor(mat);
     # link the axes
     subplot!(p, link = (r,c) -> (true, r!=c))
 end
-


### PR DESCRIPTION
``` Julia
using LearnBase
using LearnBase.LossFunctions
using MLPlots
pyplot()
```

You can treat a loss like a function.

``` Julia
plt = plot(L2DistLoss(), -2, 2, title = "Distance Based Loss Functions")
plot!(plt, L1DistLoss(), -3, 3)
plot!(plt, EpsilonInsLoss(1), -3, 3)
```

![example](https://cloud.githubusercontent.com/assets/10854026/11312542/06df92a2-8fd7-11e5-857c-693704dfb559.png)

It is also possible to plot multiple Losses at once

``` Julia
plot([ZeroOneLoss(), LogitMarginLoss(), HingeLoss(), L2HingeLoss(), ModifiedHuberLoss()],
     title = "Loss Functions for Classification")
```

![index](https://cloud.githubusercontent.com/assets/10854026/11312720/5477f756-8fd8-11e5-8a6c-40352e89933e.png)
